### PR TITLE
Set proper user agent string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,9 @@ var testSubDomain = function(subdomain, opts) {
   promises.push(got.head(domain, {
     timeout: opts.timeout,
     retries: 0,
+    headers: {
+      'user-agent': 'DevRunBot (https://epfl-devrun.github.io/devrunbot/)',
+    },
   }).then(function() {
     putDomainIsUp(domain);
   }).catch(function() {


### PR DESCRIPTION
Should fix #55 .

See https://github.com/epfl-devrun/epfl-devrun.github.io/pull/3

Example of Apache log:

```
128.179.254.168 - - [24/Aug/2017:20:52:22 +0200] "HEAD / HTTP/1.1" 301 - "-" "DevRunBot (https://epfl-devrun.github.io/devrunbot/)"
```